### PR TITLE
解决php8.2下报错

### DIFF
--- a/core/function.php
+++ b/core/function.php
@@ -609,7 +609,7 @@ function parse_shortcodes($content) {
         $placeholder = 'PRE_CODE_BLOCK_' . count($pre_code_blocks);
         $pre_code_blocks[$placeholder] = $matches[0];
         return $placeholder;
-    }, $content);
+    }, $content ?? '');
 
     foreach ($shortcodes as $tag => $function) {
         $pattern = '/\['.$tag.'(.*?)\]/is';


### PR DESCRIPTION
php8.2下报错`Deprecated: preg_replace_callback(): Passing null to parameter #3 ($subject) of type array|string is deprecated in /www/wwwroot/demo.typecho.work/usr/themes/buyu/core/function.php on line 609`